### PR TITLE
The fields "shipping" and "tax" can both be float values

### DIFF
--- a/src/Event/Purchase.php
+++ b/src/Event/Purchase.php
@@ -93,13 +93,13 @@ class Purchase extends Model\Event implements Facade\Purchase
         return $this;
     }
 
-    public function setShipping(int $cost)
+    public function setShipping(float $cost)
     {
         $this->shipping = 0 + $cost;
         return $this;
     }
 
-    public function setTax(int $tax)
+    public function setTax(float $tax)
     {
         $this->tax = $tax;
         return $this;

--- a/src/Facade/Purchase.php
+++ b/src/Facade/Purchase.php
@@ -56,17 +56,17 @@ interface Purchase
      * Shipping cost associated with a transaction.
      *
      * @var shipping
-     * @param string $cost eg. 3.33
+     * @param float $cost eg. 3.33
      */
-    public function setShipping(int $cost);
+    public function setShipping(float $cost);
 
     /**
      * Tax cost associated with a transaction.
      *
      * @var tax
-     * @param string $tax eg. 1.11
+     * @param float $tax eg. 1.11
      */
-    public function setTax(int $tax);
+    public function setTax(float $tax);
 
     /**
      * The items for the event.


### PR DESCRIPTION
Hi @aawnu, these two fields can be floats according to the documentation. I've fixed the annotations in the interface as well.