### PR TITLE
Add default event parameters

### DIFF
--- a/src/Facade/Type/DefaultEventParams.php
+++ b/src/Facade/Type/DefaultEventParams.php
@@ -4,10 +4,19 @@ namespace AlexWestergaard\PhpGa4\Facade\Type;
 
 interface DefaultEventParams
 {
+    /** @var language */
     public function setLanguage(string $lang);
+
+    /** @var page_location */
     public function setPageLocation(string $url);
+
+    /** @var page_referrer */
     public function setPageReferrer(string $url);
+
+    /** @var page_title */
     public function setPageTitle(string $title);
+
+    /** @var screen_resolution */
     public function setScreenResolution(string $wxh);
 
     public function toArray(): array;

--- a/src/Facade/Type/DefaultEventParams.php
+++ b/src/Facade/Type/DefaultEventParams.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AlexWestergaard\PhpGa4\Facade\Type;
+
+interface DefaultEventParams
+{
+    public function setLanguage(string $lang);
+    public function setPageLocation(string $url);
+    public function setPageReferrer(string $url);
+    public function setPageTitle(string $title);
+    public function setScreenResolution(string $wxh);
+
+    public function toArray(): array;
+}

--- a/src/Facade/Type/Event.php
+++ b/src/Facade/Type/Event.php
@@ -36,4 +36,10 @@ interface Event extends IO
      * @return string snake_case
      */
     public function getName(): string;
+
+    public function setLanguage(string $lang);
+    public function setPageLocation(string $url);
+    public function setPageReferrer(string $url);
+    public function setPageTitle(string $title);
+    public function setScreenResolution(string $wxh);
 }

--- a/src/Facade/Type/Event.php
+++ b/src/Facade/Type/Event.php
@@ -2,7 +2,7 @@
 
 namespace AlexWestergaard\PhpGa4\Facade\Type;
 
-interface Event extends IO
+interface Event extends IO, DefaultEventParams
 {
     /** @return array<int,string> */
     public const RESERVED_NAMES = [
@@ -36,10 +36,4 @@ interface Event extends IO
      * @return string snake_case
      */
     public function getName(): string;
-
-    public function setLanguage(string $lang);
-    public function setPageLocation(string $url);
-    public function setPageReferrer(string $url);
-    public function setPageTitle(string $title);
-    public function setScreenResolution(string $wxh);
 }

--- a/src/Helper/AbstractEvent.php
+++ b/src/Helper/AbstractEvent.php
@@ -7,6 +7,42 @@ use AlexWestergaard\PhpGa4\Exception\Ga4EventException;
 
 abstract class AbstractEvent extends AbstractIO implements Event
 {
+    protected null|string $language;
+    protected null|string $page_location;
+    protected null|string $page_referrer;
+    protected null|string $page_title;
+    protected null|string $screen_resolution;
+
+    public function setLanguage(string $lang)
+    {
+        $this->language = $lang;
+        return $this;
+    }
+
+    public function setPageLocation(string $url)
+    {
+        $this->page_location = $url;
+        return $this;
+    }
+
+    public function setPageReferrer(string $url)
+    {
+        $this->page_referrer = $url;
+        return $this;
+    }
+
+    public function setPageTitle(string $title)
+    {
+        $this->page_title = $title;
+        return $this;
+    }
+
+    public function setScreenResolution(string $wxh)
+    {
+        $this->screen_resolution = $wxh;
+        return $this;
+    }
+
     public function toArray(): array
     {
         $return = [];
@@ -32,6 +68,21 @@ abstract class AbstractEvent extends AbstractIO implements Event
         $return['params'] = parent::toArray();
 
         return $return;
+    }
+
+    public function getAllParams(): array
+    {
+        return array_unique(array_merge(
+            [
+                'language',
+                'page_location',
+                'page_referrer',
+                'page_title',
+                'screen_resolution',
+            ],
+            $this->getParams(),
+            $this->getRequiredParams()
+        ));
     }
 
     public static function new(): static

--- a/src/Helper/AbstractEvent.php
+++ b/src/Helper/AbstractEvent.php
@@ -3,6 +3,7 @@
 namespace AlexWestergaard\PhpGa4\Helper;
 
 use AlexWestergaard\PhpGa4\Facade\Type\Event;
+use AlexWestergaard\PhpGa4\Facade\Type\DefaultEventParams;
 use AlexWestergaard\PhpGa4\Exception\Ga4EventException;
 
 abstract class AbstractEvent extends AbstractIO implements Event
@@ -40,6 +41,19 @@ abstract class AbstractEvent extends AbstractIO implements Event
     public function setScreenResolution(string $wxh)
     {
         $this->screen_resolution = $wxh;
+        return $this;
+    }
+
+    public function setEventPage(DefaultEventParams $page)
+    {
+        $args = $page->toArray();
+
+        $this->language = $args['language'] ?? null;
+        $this->page_location = $args['page_location'] ?? null;
+        $this->page_referrer = $args['page_referrer'] ?? null;
+        $this->page_title = $args['page_title'] ?? null;
+        $this->screen_resolution = $args['screen_resolution'] ?? null;
+
         return $this;
     }
 

--- a/src/Helper/DefaultEventParams.php
+++ b/src/Helper/DefaultEventParams.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace AlexWestergaard\PhpGa4\Helper;
+
+use AlexWestergaard\PhpGa4\Facade\Type\DefaultEventParams as TypeDefaultEventParams;
+
+class DefaultEventParams implements TypeDefaultEventParams
+{
+    public function __construct(
+        protected null|string $language = null,
+        protected null|string $page_location = null,
+        protected null|string $page_referrer = null,
+        protected null|string $page_title = null,
+        protected null|string $screen_resolution = null
+    ) {
+    }
+
+    public function setLanguage(string $lang)
+    {
+        $this->language = $lang;
+        return $this;
+    }
+
+    public function setPageLocation(string $url)
+    {
+        $this->page_location = $url;
+        return $this;
+    }
+
+    public function setPageReferrer(string $url)
+    {
+        $this->page_referrer = $url;
+        return $this;
+    }
+
+    public function setPageTitle(string $title)
+    {
+        $this->page_title = $title;
+        return $this;
+    }
+
+    public function setScreenResolution(string $wxh)
+    {
+        $this->screen_resolution = $wxh;
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'language' => $this->language,
+            'page_location' => $this->page_location,
+            'page_referrer' => $this->page_referrer,
+            'page_title' => $this->page_title,
+            'screen_resolution' => $this->screen_resolution,
+        ];
+    }
+}

--- a/test/Unit/EventTest.php
+++ b/test/Unit/EventTest.php
@@ -420,6 +420,12 @@ final class EventTest extends TestCase
     private function populateEventByFromArray(TypeEvent $event)
     {
         return $event::fromArray([
+            'language' => 'en-US',
+            'page_location' => '/',
+            'page_referrer' => 'https://example.com/',
+            'page_title' => 'Home - Site',
+            'screen_resolution' => '1920x1080',
+            // ---
             'currency' => $this->prefill['currency'],
             'value' => 9.99,
             'affiliation' => 'affiliation',
@@ -456,6 +462,12 @@ final class EventTest extends TestCase
 
     private function populateEventByArrayable(TypeEvent $event)
     {
+        $event['language'] = 'en-US';
+        $event['page_location'] = '/';
+        $event['page_referrer'] = 'https://example.com/';
+        $event['page_title'] = 'Home - Site';
+        $event['screen_resolution'] = '1920x1080';
+
         $event['currency'] = $this->prefill['currency'];
         $event['value'] = 9.99;
         $event['affiliation'] = 'affiliation';
@@ -495,6 +507,12 @@ final class EventTest extends TestCase
         TypeEvent|Group\AddPaymentInfo|Group\AddShippingInfo|Group\AddToCart|Group\AddToWishlist|Group\Analytics|Group\BeginCheckout|Group\EarnVirtualCurrency|Group\Export|Group\GenerateLead|Group\Item|Group\JoinGroup|Group\LevelUp|Group\Login|Group\PostScore|Group\Purchase|Group\Refund|Group\RemoveFromCart|Group\Search|Group\SelectContent|Group\SelectItem|Group\SelectPromotion|Group\Share|Group\SignUp|Group\SpendVirtualCurrency|Group\UnlockAchievement|Group\ViewCart|Group\ViewItem|Group\ViewItemList|Group\ViewPromotion|Group\ViewSearchResults|Group\hasItems $event
     ) {
         $params = $event->getAllParams();
+
+        $event->setLanguage('en-US');
+        $event->setPageLocation('/');
+        $event->setPageReferrer('https://example.com/');
+        $event->setPageTitle('Home - Site');
+        $event->setScreenResolution('1920x1080');
 
         if (in_array('currency', $params)) {
             $event->setCurrency($this->prefill['currency']);


### PR DESCRIPTION
~ https://support.google.com/analytics/answer/9234069

Note

The following parameters are collected by default with every event, including [custom events](https://support.google.com/analytics/answer/12229021).

language
page_location
page_referrer
page_title
screen_resolution