### PR TITLE
Add overwrite for reserved event names to emulate GTM Events

### DIFF
--- a/src/Facade/Type/GtmEventType.php
+++ b/src/Facade/Type/GtmEventType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AlexWestergaard\PhpGa4\Facade\Type;
+
+/**
+ * Use this type to skip reserved names of events inside the EventHelper
+ */
+interface GtmEventType extends EventType
+{
+}

--- a/src/Facade/Type/GtmEventType.php
+++ b/src/Facade/Type/GtmEventType.php
@@ -3,7 +3,8 @@
 namespace AlexWestergaard\PhpGa4\Facade\Type;
 
 /**
- * Use this type to skip reserved names of events inside the EventHelper
+ * Use this type to skip reserved names of events inside the EventHelper.
+ * NOTICE: reserved names will not pass debugging, be careful with this.
  */
 interface GtmEventType extends EventType
 {

--- a/src/Helper/EventHelper.php
+++ b/src/Helper/EventHelper.php
@@ -2,6 +2,7 @@
 
 namespace AlexWestergaard\PhpGa4\Helper;
 
+use AlexWestergaard\PhpGa4\Facade\Type\GtmEventType;
 use AlexWestergaard\PhpGa4\Facade\Type\EventType;
 use AlexWestergaard\PhpGa4\Facade\Type\DefaultEventParamsType;
 use AlexWestergaard\PhpGa4\Facade\Type\CampaignType;
@@ -88,7 +89,7 @@ abstract class EventHelper extends IOHelper implements EventType
                 throw Ga4EventException::throwNameTooLong();
             } elseif (preg_match('/[^\w\d\-]/', $name)) {
                 throw Ga4EventException::throwNameInvalid();
-            } elseif (in_array($name, EventType::RESERVED_NAMES)) {
+            } elseif (in_array($name, EventType::RESERVED_NAMES) && !($this instanceof GtmEventType)) {
                 throw Ga4EventException::throwNameReserved($name);
             } else {
                 $return['name'] = $name;


### PR DESCRIPTION
NOTE: Reserved names will not pass debugging; use this at own discretion.