### PR TITLE
Update Ga4Exception.php

### DIFF
--- a/src/Exception/Ga4Exception.php
+++ b/src/Exception/Ga4Exception.php
@@ -39,7 +39,7 @@ class Ga4Exception extends \Exception implements Ga4ExceptionType
 
     public static function throwMissingApiSecret()
     {
-        return new static("Timestamp must be numeric", static::REQUEST_MISSING_API_SECRET);
+        return new static("Missing API Secret", static::REQUEST_MISSING_API_SECRET);
     }
 
     public static function throwMicrotimeInvalid($inp)


### PR DESCRIPTION
set better error message for missing API Secret - because ... well the current one is confusing AF 😄 