### PR TITLE
Add info to pageview about not being official event

### DIFF
--- a/src/Event/PageView.php
+++ b/src/Event/PageView.php
@@ -9,6 +9,7 @@ use AlexWestergaard\PhpGa4\Facade;
  * This is not an official SST Event, please use this with caution
  * 
  * @link https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag
+ * @deprecated unofficial-event
  * @internal
  */
 class PageView extends EventHelper implements Facade\Type\DefaultEventParamsType

--- a/src/Event/PageView.php
+++ b/src/Event/PageView.php
@@ -5,6 +5,12 @@ namespace AlexWestergaard\PhpGa4\Event;
 use AlexWestergaard\PhpGa4\Helper\EventHelper;
 use AlexWestergaard\PhpGa4\Facade;
 
+/**
+ * This is not an official SST Event, please use this with caution
+ * 
+ * @link https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag
+ * @internal
+ */
 class PageView extends EventHelper implements Facade\Type\DefaultEventParamsType
 {
     protected null|string $method;


### PR DESCRIPTION
Marking event as deprecated and internal to warn people of using it without caution.