### PR TITLE
Fix item::item_category index conversion

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -154,6 +154,28 @@ class Item extends Helper\IOHelper implements Facade\Type\ItemType
         return $return;
     }
 
+    public function toArray(): array
+    {
+        $res = parent::toArray();
+
+        if (!isset($res['item_category'])) {
+            return $res;
+        }
+
+        $categories = $res['item_category'];
+        unset($res['item_category']);
+
+        if (is_array($categories)) {
+            foreach ($categories as $k => $val) {
+                $tag = 'item_category' . ($k > 0 ? $k + 1 : '');
+
+                $res[$tag] = $val;
+            }
+        }
+
+        return $res;
+    }
+
     public static function new(): static
     {
         return new static();

--- a/test/Unit/ItemTest.php
+++ b/test/Unit/ItemTest.php
@@ -44,7 +44,7 @@ final class ItemTest extends TestCase
         $this->assertArrayHasKey('quantity', $asArray);
         $this->assertArrayHasKey('index', $asArray);
         $this->assertArrayHasKey('item_category', $asArray);
-        $this->assertIsArray($asArray['item_category']);
+        $this->assertIsNotArray($asArray['item_category']);
     }
 
     public function test_can_configure_arrayable()

--- a/test/Unit/ItemTest.php
+++ b/test/Unit/ItemTest.php
@@ -118,4 +118,21 @@ final class ItemTest extends TestCase
         $this->assertArrayHasKey('price', $arr);
         $this->assertArrayHasKey('quantity', $arr);
     }
+
+    public function test_can_convert_item_category_to_index_names()
+    {
+        $arr = Item::new()
+            ->setItemId("123")
+            ->addItemCategory("a")
+            ->addItemCategory("b")
+            ->addItemCategory("c")
+            ->toArray();
+
+        $this->assertArrayHasKey('item_category', $arr);
+        $this->assertArrayHasKey('item_category2', $arr);
+        $this->assertArrayHasKey('item_category3', $arr);
+
+        $this->assertArrayNotHasKey('item_category0', $arr);
+        $this->assertArrayNotHasKey('item_category1', $arr);
+    }
 }


### PR DESCRIPTION
Item_category is currently grouped in an array but is supposed to be sent to Google Analytics as individual lines appended by index number like:

```json
{
  "items": [
    {
      "index": 0,
      "item_brand": "Google",
      "item_category": "Apparel",
      "item_category2": "Adult",
      "item_category3": "Shirts",
    //...
}
```

- https://developers.google.com/analytics/devguides/collection/ga4/item-scoped-ecommerce