### PR TITLE
Update static parameters to match constructor of Analytics.php

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -193,7 +193,7 @@ class Analytics extends Helper\IOHelper implements Facade\Type\AnalyticsType
         }
     }
 
-    public static function new(string $measurementId, string $apiSecret, bool $debug = false): static
+    public static function new(string $measurement_id, string $api_secret, bool $debug = false): static
     {
         return new static($measurementId, $apiSecret, $debug);
     }

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -195,7 +195,7 @@ class Analytics extends Helper\IOHelper implements Facade\Type\AnalyticsType
 
     public static function new(string $measurement_id, string $api_secret, bool $debug = false): static
     {
-        return new static($measurementId, $apiSecret, $debug);
+        return new static($measurement_id, $api_secret, $debug);
     }
 
     /**


### PR DESCRIPTION
This should remove confusion from copying the readme code directly.